### PR TITLE
Don't add show_advanced_fonts control if theme doesn't define them

### DIFF
--- a/customizer.php
+++ b/customizer.php
@@ -351,7 +351,7 @@ class Typecase_Customizer extends Typecase {
 
 			$default = array(
 				'' => 'Select a Font',
-				$font_location['default'] => $font_location['default'] . ' (default)',
+				$font_location['default'] => !empty( $font_location['default_title'] ) ? $font_location['default_title'] : sprintf( esc_html__( '%s (default)', 'typecase' ), $font_location['default'] ),
 			);
 
 			$wp_customize->add_control(

--- a/customizer.php
+++ b/customizer.php
@@ -283,11 +283,6 @@ class Typecase_Customizer extends Typecase {
 
 			}
 
-		}
-
-		if( !$has_panel ){
-			$this->display_inputs( $theme_font_locations, $wp_customize );
-		} else{
 			$wp_customize->add_setting(
 				'show_advanced_fonts',
 				array( 'transport' => 'postMessage' )
@@ -301,6 +296,11 @@ class Typecase_Customizer extends Typecase {
 					'section' => 'theme_fonts_main',
 				)
 			);
+
+		}
+
+		if( !$has_panel ){
+			$this->display_inputs( $theme_font_locations, $wp_customize );
 		}
 
 	}

--- a/typecase.php
+++ b/typecase.php
@@ -456,6 +456,11 @@ EOT;
 					$import_url .= '|';
 
 				$import_url .= str_replace(" ","+",$family).$this->stringify_font_part($weights).$this->stringify_font_part($charsets);
+				
+				// Skip font styles if no selectors are defined
+				if ( empty( $selectors ) ) {
+					continue;
+				}
 
 				$selectors = explode("|",$selectors);
 


### PR DESCRIPTION
This prevents the little checkbox to show or hide advanced font options from being added to the customizer when the theme does not have any advanced options defined.
