### PR TITLE
Fix undefined string offset error

### DIFF
--- a/typecase.php
+++ b/typecase.php
@@ -438,6 +438,10 @@ EOT;
 	public function display_frontend(){
 		$fonts = get_option('typecase_fonts');
 
+		if ( empty( $fonts ) || !is_array( $fonts ) || !isset( $fonts[0] ) ) {
+			return;
+		}
+
 		if( $fonts[0] ){
 
 			$apiUrl = &$this->api_url;


### PR DESCRIPTION
Fixes PHP Notice:

```
Notice: Uninitialized string offset: 0 in /var/www/html/wp/wp-content/plugins/typecase/typecase.php on line 441
```

To reproduce:
- Add a font to your collection.
- Remove all fonts from your collection.
- Reload a page on the frontend.
